### PR TITLE
fix Insufficient error handling in file operation 

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -733,8 +733,13 @@ class Translator
      */
     private function markIdenticalTranslationsAsFuzzy($poFile)
     {
-        $content = file_get_contents($poFile);
-        if ($content === false || $content === '') {
+        $content = @file_get_contents($poFile);
+        if ($content === false) {
+            fwrite(STDERR, "Warning: Failed to read file: {$poFile}\n");
+            return;
+        }
+        if ($content === '') {
+            fwrite(STDERR, "Warning: Empty file: {$poFile}\n");
             return;
         }
 


### PR DESCRIPTION
Adds warning display when marking identical translations as fuzzy to avoid silent failures.

fix Insufficient error handling in file operation #11 