### PR TITLE
drop test devDependencies and install with --omit=dev

### DIFF
--- a/bin/setup-potomatic.php
+++ b/bin/setup-potomatic.php
@@ -47,7 +47,7 @@ chdir($potomaticDir);
 $isWindows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
 $npmCommand = $isWindows ? 'npm.cmd' : 'npm';
 
-passthru("{$npmCommand} install --production 2>&1", $returnCode);
+passthru("{$npmCommand} install --omit=dev --production 2>&1", $returnCode);
 
 if ($returnCode === 0) {
     echo "✓ Potomatic setup complete!\n";

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         ],
         "setup-potomatic": [
             "@php -r \"echo '\\n\\u1F4E6 Setting up Potomatic...\\n';\"",
-            "cd potomatic && npm install --silent || echo 'Warning: npm not found. Please install Node.js from https://nodejs.org/'",
+            "cd potomatic && npm install --omit=dev --silent || echo 'Warning: npm not found. Please install Node.js from https://nodejs.org/'",
             "@php -r \"echo '\\u2713 Potomatic ready!\\n\\n';\""
         ]
     },

--- a/potomatic/package.json
+++ b/potomatic/package.json
@@ -55,19 +55,5 @@
 		"openai": "^4.0.0",
 		"tiktoken": "^1.0.21",
 		"zod": "^3.25.23"
-	},
-	"devDependencies": {
-		"@vitest/coverage-v8": "^4.0.10",
-		"eslint": "^8.57.1",
-		"eslint-config-prettier": "^10.1.5",
-		"eslint-config-standard": "^17.1.0",
-		"eslint-plugin-import": "^2.31.0",
-		"eslint-plugin-node": "^11.1.0",
-		"eslint-plugin-promise": "^6.6.0",
-		"execa": "^8.0.1",
-		"nock": "^13.5.4",
-		"prettier": "^3.5.3",
-		"tmp": "^0.2.3",
-		"vitest": "^3.1.4"
 	}
 }


### PR DESCRIPTION
We need to do this to avoid installing devDependencies in consumer installs and prevent conflicts with potomatic's own devDependencies.