### PR TITLE
Add PHP shebang to publishpress-translate binary

### DIFF
--- a/bin/publishpress-translate
+++ b/bin/publishpress-translate
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 /**
  * PublishPress Translation CLI


### PR DESCRIPTION
Ensure the CLI can be executed directly via the shell or Composer vendor bin by adding #!/usr/bin/env php as the first line.

Fixed Missed shebang ling for the binary file #28