### PR TITLE
fix: use 'replace' method for PO uploads when VCS is disabled

### DIFF
--- a/src/WeblateClient.php
+++ b/src/WeblateClient.php
@@ -718,6 +718,9 @@ class WeblateClient
                 $this->removeFuzzyFromPoHeader($poFilePath);
                 $this->normalizePluralFormsForWeblate($language, $poFilePath);
 
+                $hasVcs = $this->componentHasVcs($projectSlug, $componentSlug);
+                $method = $hasVcs ? 'translate' : 'replace';
+
                 $response = $this->client->post(
                     "translations/{$projectSlug}/{$componentSlug}/{$weblateLanguage}/file/",
                     [
@@ -728,7 +731,7 @@ class WeblateClient
                             ],
                             [
                                 'name'     => 'method',
-                                'contents' => 'translate',
+                                'contents' => $method,
                             ],
                         ],
                     ]


### PR DESCRIPTION
When WEBLATE_SKIP_VCS=true, the POT file is uploaded with method 'source' which creates untranslated strings in Weblate. However, PO files were being uploaded with method 'translate', which only imports translations for strings that already exist with translations in Weblate.

Now uses method 'replace' for PO uploads when VCS is disabled, ensuring translations are properly imported. When VCS is enabled, continues to use method 'translate' to preserve the VCS workflow.