### PR TITLE
Add translation exclusion system with dictionary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,92 @@ The following environment variables control advanced behaviour:
   export SKIP_LANGUAGES=it_IT,es_ES,fr_FR,pt_BR
   ```
 
+### Excluding Words from Translation
+
+The translation library automatically excludes certain terms from being translated. You can add your own exclusions too.
+
+#### Built-in Dictionary (Always Applied)
+
+The library includes a built-in `config/dictionaries.json` with pre-defined terms that are automatically excluded from translation in ALL languages:
+
+**Brand Terms (automatically excluded):**
+- PublishPress
+- TaxoPress
+- Tag-Groups
+- MetaSlider
+- WordPress
+- WooCommerce
+- Lightbox
+
+**Technical Terms (automatically excluded):**
+- taxonomy
+- taxonomies
+- post type
+- custom field
+- shortcode
+- widget
+- admin
+- dashboard
+
+#### Adding Custom Exclusions with TRANSLATION_OVERRIDES
+
+Add the `TRANSLATION_OVERRIDES` variable to your plugin's `.env` file to exclude additional words:
+
+**Add to `.env` in your plugin:**
+
+```env
+
+# List of keywords to not be translated
+TRANSLATION_OVERRIDES="shortlink,shortlinks,metaslider,capabilities"
+
+```
+
+**Format options:**
+- `term` - Prevents "term" from being translated (keeps original)
+- `term=Custom Form` - Uses "Custom Form" as the untranslated value
+
+**Examples:**
+
+```env
+# Simple exclusions
+TRANSLATION_OVERRIDES="Dashboard,Admin Panel,REST API"
+
+# With custom forms
+TRANSLATION_OVERRIDES="post type=Post Type, custom field=Custom Field, rest api=REST API"
+
+# Mixed (simple + custom forms)
+TRANSLATION_OVERRIDES="Dashboard, post type=Post Type, lightbox, advanced settings=Advanced Settings"
+```
+
+**From CLI:**
+
+Linux/Mac:
+```bash
+export TRANSLATION_OVERRIDES="shortlink,shortlinks"
+composer translate
+```
+
+Windows PowerShell:
+```powershell
+$env:TRANSLATION_OVERRIDES = "shortlink,shortlinks"
+composer translate
+```
+
+Windows CMD:
+```cmd
+set TRANSLATION_OVERRIDES=shortlink,shortlinks
+composer translate
+```
+
+#### How It Works
+
+When translating:
+1. Built-in dictionary from the library is loaded
+2. `TRANSLATION_OVERRIDES` from `.env` is loaded (if available)
+3. Both are merged into a single dictionary
+4. The complete dictionary is passed to Potomatic
+5. Potomatic excludes ALL these terms in every target language
+
 ### Complete Translation Workflow
 
 #### 1. Run Translation (Full Cycle)

--- a/config/dictionaries.json
+++ b/config/dictionaries.json
@@ -5,7 +5,8 @@
         "Tag-Groups": "Tag-Groups",
         "MetaSlider": "MetaSlider",
         "WordPress": "WordPress",
-        "WooCommerce": "WooCommerce"
+        "WooCommerce": "WooCommerce",
+        "Lightbox": "Lightbox"
     },
     "technical_terms": {
         "taxonomy": "taxonomy",

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -586,6 +586,181 @@ class Translator
     }
 
     /**
+     * Revert translations for dictionary words in PO file
+     *
+     * This handles terms from:
+     * - config/dictionaries.json
+     * - composer.json extra.plugin_name
+     * - TRANSLATION_OVERRIDES environment variable
+     *
+     * @param string $poFile Path to PO file
+     */
+    private function revertDictionaryTranslations($poFile)
+    {
+        $dictionary = $this->getDictionaryTermsForExclusion();
+        if (empty($dictionary)) {
+            return;
+        }
+
+        $content = @file_get_contents($poFile);
+        if ($content === false || $content === '') {
+            return;
+        }
+
+        $lines = explode("\n", $content);
+        $result = [];
+        $i = 0;
+        $modified = false;
+
+        while ($i < count($lines)) {
+            $line = $lines[$i];
+
+            if (preg_match('/^msgid\s+"(.+)"$/', $line, $msgidMatch)) {
+                $msgid = stripcslashes($msgidMatch[1]);  // Unescape PO format
+
+                // Check if this msgid is in the dictionary
+                if (isset($dictionary[$msgid]) && $i + 1 < count($lines)) {
+                    $nextLine = $lines[$i + 1];
+
+                    // Handle single-line msgstr
+                    if (preg_match('/^msgstr\s+"(.*?)"$/', $nextLine)) {
+                        $expectedValue = $dictionary[$msgid];
+                        $escapedValue = addcslashes($expectedValue, '"\\');
+                        $expectedMsgstr = 'msgstr "' . $escapedValue . '"';
+
+                        // Only revert if msgstr differs from dictionary value
+                        if ($nextLine !== $expectedMsgstr) {
+                            $result[] = $line;
+                            $result[] = $expectedMsgstr;
+                            $i += 2;
+                            $modified = true;
+                            continue;
+                        }
+                    }
+                    // Handle multiline msgstr
+                    elseif (preg_match('/^msgstr\s+""$/', $nextLine)) {
+                        $msgstrLines = [$nextLine];
+                        $j = $i + 2;
+                        
+                        while ($j < count($lines) && preg_match('/^\s*"/', $lines[$j])) {
+                            $msgstrLines[] = $lines[$j];
+                            $j++;
+                        }
+                        
+                        // Reconstruct multiline msgstr into single string
+                        $fullMsgstr = '';
+                        foreach ($msgstrLines as $msgstrLine) {
+                            if (preg_match('/^\s*"(.*)"/', $msgstrLine, $m)) {
+                                $fullMsgstr .= stripcslashes($m[1]);
+                            }
+                        }
+                        
+                        // Only revert if msgstr differs from dictionary value
+                        if ($fullMsgstr !== $dictionary[$msgid]) {
+                            $result[] = $line;
+                            $expectedValue = $dictionary[$msgid];
+                            $escapedValue = addcslashes($expectedValue, '"\\');
+                            $result[] = 'msgstr "' . $escapedValue . '"';
+                            $i = $j;
+                            $modified = true;
+                            continue;
+                        }
+                        
+                        // Skip the collected multiline msgstr
+                        $i = $j;
+                    }
+                }
+            }
+
+            $result[] = $line;
+            $i++;
+        }
+
+        if ($modified) {
+            if (@file_put_contents($poFile, implode("\n", $result)) === false) {
+                fwrite(STDERR, "Warning: Failed to write reverted dictionary translations to {$poFile}\n");
+            }
+        }
+    }
+
+    /**
+     * Get all dictionary terms for exclusion
+     * Combines config/dictionaries.json, plugin name, and TRANSLATION_OVERRIDES
+     *
+     * @return array Dictionary terms (key-value pairs)
+     */
+    private function getDictionaryTermsForExclusion(): array
+    {
+        $dictionary = [];
+
+        // Load config/dictionaries.json if it exists
+        $configDictPath = $this->pluginRoot . '/config/dictionaries.json';
+        if (file_exists($configDictPath)) {
+            $configContent = @file_get_contents($configDictPath);
+            if ($configContent) {
+                $configDict = @json_decode($configContent, true);
+                if (is_array($configDict)) {
+                    // Flatten nested dictionary structure
+                    foreach ($configDict as $key => $value) {
+                        if (is_array($value)) {
+                            $dictionary = array_merge($dictionary, $value);
+                        } else {
+                            $dictionary[$key] = $value;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add plugin name if configured
+        $pluginName = $this->getPluginNameForExclusion();
+        if ($pluginName) {
+            $dictionary[$pluginName] = $pluginName;
+        }
+
+        // Add TRANSLATION_OVERRIDES if set
+        $raw = getenv('TRANSLATION_OVERRIDES');
+        if ($raw) {
+            $overrides = $this->parseTranslationOverrides($raw);
+            if (!empty($overrides)) {
+                $dictionary = array_merge($dictionary, $overrides);
+            }
+        }
+
+        return $dictionary;
+    }
+
+    /**
+     * Clean up temporary dictionary directory
+     *
+     * @return void
+     */
+    private function cleanupTemporaryDictionaryDirectory(): void
+    {
+        $baseDir = dirname(__DIR__) . '/translations-override';
+        
+        if (!is_dir($baseDir)) {
+            return;
+        }
+
+        $dictFile = $baseDir . '/dictionary.json';
+        if (file_exists($dictFile)) {
+            @unlink($dictFile);
+        }
+
+        if (is_dir($baseDir)) {
+            $files = @scandir($baseDir);
+            if ($files === false) {
+                return;
+            }
+
+            if (count($files) === 2 && in_array('.', $files) && in_array('..', $files)) {
+                @rmdir($baseDir);
+            }
+        }
+    }
+
+    /**
      * Repair plural entries where msgstr[0] contains pipe-delimited forms.
      *
      * @param string $poFile Path to PO file
@@ -775,6 +950,79 @@ class Translator
         return getenv('OPENAI_API_KEY') ?: null;
     }
 
+    private function parseTranslationOverrides(string $raw): array
+    {
+        $raw = trim($raw);
+        if ($raw === '') {
+            return [];
+        }
+
+        $result = [];
+        $parts = array_filter(array_map('trim', explode(',', $raw)), static function ($v) {
+            return $v !== '';
+        });
+
+        foreach ($parts as $part) {
+            $eqPos = strpos($part, '=');
+            if ($eqPos === false) {
+                $source = trim($part);
+                $target = trim($part);
+            } else {
+                $source = trim(substr($part, 0, $eqPos));
+                $target = trim(substr($part, $eqPos + 1));
+            }
+
+            // Skip empty keys or values after trimming
+            if ($source === '' || $target === '') {
+                continue;
+            }
+
+            $result[$source] = $target;
+        }
+
+        return $result;
+    }
+
+    private function ensurePotomaticOverridesDictionary(): ?string
+    {
+        $dictionary = $this->getDictionaryTermsForExclusion();
+        
+        if (empty($dictionary)) {
+            return null;
+        }
+
+        // Create temporary directory for dictionary in the library root
+        $baseDir = dirname(__DIR__) . '/translations-override';
+        if (!is_dir($baseDir)) {
+            if (@mkdir($baseDir, 0755, true) === false) {
+                return null;
+            }
+        }
+
+        // Verify directory is writable
+        if (!is_writable($baseDir)) {
+            return null;
+        }
+
+        // Write merged dictionary file
+        $dictFile = $baseDir . '/dictionary.json';
+        $jsonContent = json_encode($dictionary, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_ERROR_INF_AS_NULL);
+        
+        if ($jsonContent === false) {
+            return null; 
+        }
+        
+        if (@file_put_contents($dictFile, $jsonContent) === false) {
+            return null;
+        }
+
+        if (!file_exists($dictFile) || !is_readable($dictFile)) {
+            return null;
+        }
+
+        return $baseDir;
+    }
+
     /**
      * Build Potomatic command
      *
@@ -815,6 +1063,12 @@ class Translator
         $apiKey = $this->getApiKey();
         if ($apiKey) {
             $cmd .= ' --api-key ' . escapeshellarg($apiKey);
+        }
+
+        $overridesDictionaryDir = $this->ensurePotomaticOverridesDictionary();
+        if ($overridesDictionaryDir) {
+            $cmd .= ' --use-dictionary';
+            $cmd .= ' --dictionary-path ' . escapeshellarg($overridesDictionaryDir);
         }
 
         return $cmd;
@@ -1097,6 +1351,9 @@ class Translator
         echo str_repeat('=', 50) . "\n";
         echo "✨ Upload " . ($success ? 'complete' : 'finished with errors') . " for {$pluginSlug}!\n\n";
 
+        // Clean up temporary dictionary directory
+        $this->cleanupTemporaryDictionaryDirectory();
+
         return $success;
     }
 
@@ -1246,6 +1503,8 @@ class Translator
                         
                         $this->revertPluginNameTranslations($poFile);
                         
+                        $this->revertDictionaryTranslations($poFile);
+                        
                         $moFile = $this->languagesDir . '/' . $textDomain . '-' . $wpLocale . '.mo';
                         $this->convertPoToMo($poFile, $moFile);
 
@@ -1276,6 +1535,9 @@ class Translator
             echo str_repeat('=', 50) . "\n";
             echo "✨ Downloaded {$totalDownloaded} translation files!\n\n";
         }
+
+        // Clean up temporary dictionary directory
+        $this->cleanupTemporaryDictionaryDirectory();
 
         return $success;
     }
@@ -1606,6 +1868,8 @@ class Translator
                         
                         $this->revertPluginNameTranslations($poFile);
                         
+                        $this->revertDictionaryTranslations($poFile);
+                        
                         $this->markIdenticalTranslationsAsFuzzy($poFile);
 
                         $baseName = basename($poFile, '.po');
@@ -1642,6 +1906,9 @@ class Translator
 
         echo str_repeat('=', 50) . "\n";
         echo "✨ Translation " . ($success ? 'complete' : 'finished with errors') . " for {$pluginSlug}!\n\n";
+
+        // Clean up temporary dictionary directory
+        $this->cleanupTemporaryDictionaryDirectory();
 
         return $success;
     }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -770,6 +770,77 @@ class Translator
     }
 
     /**
+     * Remove fuzzy flag from dictionary terms
+     * Dictionary terms should never be marked as fuzzy since they are intentionally untranslated
+     *
+     * @param string $poFile Path to PO file
+     */
+    private function removeFuzzyFromDictionaryTerms($poFile)
+    {
+        $dictionary = $this->getDictionaryTermsForExclusion();
+        if (empty($dictionary)) {
+            return;
+        }
+
+        $content = @file_get_contents($poFile);
+        if ($content === false || $content === '') {
+            return;
+        }
+
+        $lines = explode("\n", $content);
+        $result = [];
+        $i = 0;
+        $modified = false;
+
+        while ($i < count($lines)) {
+            $line = $lines[$i];
+
+            // Look for fuzzy comment line
+            if (preg_match('/^#,\s*(.*)fuzzy(.*)$/', $line, $commentMatch)) {
+                $beforeFuzzy = trim($commentMatch[1], ' ,');
+                $afterFuzzy = trim($commentMatch[2], ' ,');
+
+                // Look ahead to see if the next msgid is in our dictionary
+                $j = $i + 1;
+                while ($j < count($lines) && preg_match('/^\s*(?:#|$)/', $lines[$j])) {
+                    $j++;
+                }
+
+                if ($j < count($lines) && preg_match('/^msgid\s+"(.+)"$/', $lines[$j], $msgidMatch)) {
+                    $msgid = stripcslashes($msgidMatch[1]);
+
+                    // If this msgid is in the dictionary, remove fuzzy
+                    if (isset($dictionary[$msgid])) {
+                        // Reconstruct the comment without "fuzzy"
+                        $commentParts = array_filter([$beforeFuzzy, $afterFuzzy]);
+                        if (empty($commentParts)) {
+                            // No other flags, skip the entire comment line
+                            $i++;
+                            $modified = true;
+                            continue;
+                        } else {
+                            // Keep other flags
+                            $result[] = '#, ' . implode(', ', $commentParts);
+                            $i++;
+                            $modified = true;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            $result[] = $line;
+            $i++;
+        }
+
+        if ($modified) {
+            if (@file_put_contents($poFile, implode("\n", $result)) === false) {
+                fwrite(STDERR, "Warning: Failed to remove fuzzy flags from dictionary terms in {$poFile}\n");
+            }
+        }
+    }
+
+    /**
      * Repair plural entries where msgstr[0] contains pipe-delimited forms.
      *
      * @param string $poFile Path to PO file
@@ -1522,6 +1593,8 @@ class Translator
                         
                         $this->revertDictionaryTranslations($poFile);
                         
+                        $this->removeFuzzyFromDictionaryTerms($poFile);
+                        
                         $moFile = $this->languagesDir . '/' . $textDomain . '-' . $wpLocale . '.mo';
                         $this->convertPoToMo($poFile, $moFile);
 
@@ -1888,6 +1961,9 @@ class Translator
                         $this->revertDictionaryTranslations($poFile);
                         
                         $this->markIdenticalTranslationsAsFuzzy($poFile);
+
+                        // Remove fuzzy flag from dictionary terms (they're intentionally untranslated, not "fuzzy")
+                        $this->removeFuzzyFromDictionaryTerms($poFile);
 
                         $baseName = basename($poFile, '.po');
                         $moFile = $this->languagesDir . '/' . $baseName . '.mo';

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -743,21 +743,30 @@ class Translator
             return;
         }
 
+        echo "🧹 Deleting temporary directory for keywords exclusion...\n";
+
+        // Remove dictionary.json file if it exists
+        // This is the ONLY file we create in this directory, NOT config/dictionaries.json
         $dictFile = $baseDir . '/dictionary.json';
         if (file_exists($dictFile)) {
             @unlink($dictFile);
         }
 
+        // Try to remove the directory if it's empty
+        // Only remove if we created it (it should only contain dictionary.json)
         if (is_dir($baseDir)) {
             $files = @scandir($baseDir);
             if ($files === false) {
                 return;
             }
-
+            
+            // Check if directory only contains . and .. (empty)
             if (count($files) === 2 && in_array('.', $files) && in_array('..', $files)) {
                 @rmdir($baseDir);
             }
         }
+
+        echo "✓ Cleanup complete\n\n";
     }
 
     /**
@@ -991,35 +1000,43 @@ class Translator
             return null;
         }
 
+        echo "📚 Creating temporary directory for keywords exclusion...\n";
+
         // Create temporary directory for dictionary in the library root
         $baseDir = dirname(__DIR__) . '/translations-override';
         if (!is_dir($baseDir)) {
             if (@mkdir($baseDir, 0755, true) === false) {
+                fwrite(STDERR, "⚠️  Failed to create temporary directory for keywords exclusion, proceeding with translations\n\n");
                 return null;
             }
         }
 
         // Verify directory is writable
         if (!is_writable($baseDir)) {
+            fwrite(STDERR, "⚠️  Failed to create temporary directory for keywords exclusion, proceeding with translations\n\n");
             return null;
         }
 
         // Write merged dictionary file
         $dictFile = $baseDir . '/dictionary.json';
-        $jsonContent = json_encode($dictionary, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_ERROR_INF_AS_NULL);
+        $jsonContent = json_encode($dictionary, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
         
         if ($jsonContent === false) {
-            return null; 
+            fwrite(STDERR, "⚠️  Failed to create temporary directory for keywords exclusion, proceeding with translations\n\n");
+            return null;  // JSON encoding failed
         }
         
         if (@file_put_contents($dictFile, $jsonContent) === false) {
+            fwrite(STDERR, "⚠️  Failed to create temporary directory for keywords exclusion, proceeding with translations\n\n");
             return null;
         }
 
         if (!file_exists($dictFile) || !is_readable($dictFile)) {
+            fwrite(STDERR, "⚠️  Failed to create temporary directory for keywords exclusion, proceeding with translations\n\n");
             return null;
         }
 
+        echo "✓ Keywords exclusion directory ready\n\n";
         return $baseDir;
     }
 


### PR DESCRIPTION
Add translation exclusion system with dictionary support

- Implement automatic exclusion of keywords, brand names, and technical terms from translation. 
- Combines built-in dictionary, plugin name, and user-defined overrides via TRANSLATION_OVERRIDES environment variable. 
- Includes dictionary term reversion for already-translated files