### PR TITLE
prevent duplicate locale files when explicit language is specified

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -290,7 +290,10 @@ class Translator
 
         $lang = strtolower($code);
 
-        if (is_dir($this->languagesDir)) {
+        // Only search for existing regional variants if languages weren't explicitly set.
+        // When custom target languages are specified, respect them as-is to avoid creating
+        // unintended regional variants
+        if (!$this->customTargetLanguages && is_dir($this->languagesDir)) {
             $files = glob($this->languagesDir . "/*-{$lang}_*.po");
             if ($files) {
                 if (preg_match('/-(' . preg_quote($lang, '/') . '_[A-Z]{2,})\.po$/', $files[0], $m)) {


### PR DESCRIPTION
When a user specified a base language code like 'ja' via --languages, the reverseMapWeblateLanguage() method would search the filesystem for existing regional variants and return those instead of respecting the explicitly requested language code.

This caused both the base language file (ja.po) and the unintended regional variant (ja_JA.po) to be created during translation.

Fix: Skip filesystem-based variant detection when customTargetLanguages is true (i.e., when languages were explicitly specified by the user). This ensures that user-specified language codes are respected as-is, while still allowing automatic variant detection for default behavior.
#72 