### PR TITLE
Fix multi-line msgstr entries being ignored in PO to MO conversion

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -1443,6 +1443,14 @@ class Translator
                 $currentEntry = ['msgid' => $this->extractString($line), 'msgstr' => ''];
             } elseif (strpos($line, 'msgstr') === 0 && $currentEntry) {
                 $currentEntry['msgstr'] = $this->extractString($line);
+            } elseif ($line[0] === '"' && $currentEntry !== null) {
+                // Handle continuation lines (multi-line strings)
+                $continuationText = $this->extractString($line);
+                if ($currentEntry['msgstr'] !== '') {
+                    $currentEntry['msgstr'] .= $continuationText;
+                } else if ($currentEntry['msgid'] !== '') {
+                    $currentEntry['msgid'] .= $continuationText;
+                }
             }
         }
 


### PR DESCRIPTION
-Adds proper handling for continuation lines by concatenating them with the msgid or msgstr value they belong to.

#80 