### PR TITLE
Remove duplicate location references from PO files during sync

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -1305,6 +1305,7 @@ class Translator
                         $this->validatePluralEntries($poFile);
 
                         $this->weblateClient->cleanupDuplicatePoHeaders($poFile);
+                        $this->weblateClient->removeDuplicateReferences($poFile);
                         
                         $this->revertPluginNameTranslations($poFile);
                         
@@ -1670,6 +1671,7 @@ class Translator
                     foreach ($poFiles as $poFile) {
                         if ($this->weblateClient) {
                             $this->weblateClient->cleanupDuplicatePoHeaders($poFile);
+                            $this->weblateClient->removeDuplicateReferences($poFile);
                         }
 
                         $this->repairPluralPipeDelimitedEntries($poFile);

--- a/src/WeblateClient.php
+++ b/src/WeblateClient.php
@@ -619,7 +619,7 @@ class WeblateClient
      * @param string $poFilePath
      * @return void
      */
-    private function removeDuplicateReferences($poFilePath)
+    public function removeDuplicateReferences($poFilePath)
     {
         $content = @file_get_contents($poFilePath);
         if ($content === false || $content === '') {


### PR DESCRIPTION
Duplicate location comment lines (#:) were accumulating in .po files on each compose translate run, particularly affecting excluded languages since they weren't being processed during upload.

- Make removeDuplicateReferences() public in WeblateClient
- Clean duplicate references during Weblate download
- Clean duplicate references after Potomatic translation