### PR TITLE
Remove duplicate po entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ AI-powered translation automation for PublishPress plugins using Potomatic, Open
         "translate:custom": "vendor/bin/publishpress-translate --languages",
         "translate:force": "vendor/bin/publishpress-translate --force",
         "translate:force-custom": "vendor/bin/publishpress-translate --force --languages",
-        "translate:repair-plurals": "php vendor/bin/publishpress-translate --repair-plurals",
+        "translate:repair-plurals": "vendor/bin/publishpress-translate --repair-plurals",
+        "translate:clean-po": "vendor/bin/publishpress-translate --clean-po",
+        "translate:sync-files": "vendor/bin/publishpress-translate --sync-files"
     }
 }
 ```
@@ -191,6 +193,10 @@ The following environment variables control advanced behaviour:
   export SKIP_LANGUAGES=it_IT,es_ES,fr_FR,pt_BR
   ```
 
+```.env file
+SKIP_LANGUAGES=it_IT,es_ES,fr_FR,pt_BR,de_DE
+```
+
 ### Complete Translation Workflow
 
 #### 1. Run Translation (Full Cycle)
@@ -266,6 +272,12 @@ vendor/bin/publishpress-translate --upload --languages=de_DE,fr_FR
 
 # Repair malformed plural entries in existing .po files
 vendor/bin/publishpress-translate --repair-plurals
+
+# Clean duplicate entries from all .po files
+vendor/bin/publishpress-translate --clean-po
+
+# Synchronize .po, .mo, .l10n.php and .json files (ensure .mo, .l10n.php and .json are up to date)
+vendor/bin/publishpress-translate --sync-files
 ```
 
 #### 4. Repair Malformed Plural Entries
@@ -285,7 +297,53 @@ vendor/bin/publishpress-translate --repair-plurals
 
 **Note:** New translations are automatically repaired during the translation process, so you only need this for existing files.
 
-**Note:** The library automatically detects your environment (dev-workspace vs plugin root) and uses the correct vendor path.
+#### 5. Clean Duplicate Entries
+
+Remove duplicate extracted comments from all `.po` files:
+
+```bash
+# Clean duplicates from all .po files in the languages directory
+vendor/bin/publishpress-translate --clean-po
+```
+
+**What this does:**
+- Scans all `.po` files for duplicate extracted comments (`#.` lines)
+- Removes redundant comment lines within each entry
+- Regenerates corresponding `.mo` files for modified files
+- Reports which files were cleaned
+
+**When to use:**
+- After downloading from Weblate (if duplicates accumulated)
+- Before uploading to Weblate to keep files clean
+- As maintenance on skipped languages (which shouldn't be touched by AI translation)
+- Works independently of translation workflow
+
+**Important:** This command only processes `.po` files and doesn't interact with Weblate or run AI translation.
+
+#### 6. Synchronize .po and Generated Translation Files
+
+Ensure your `.mo`, `.json`, and `.l10n.php` files are in sync with `.po` source files:
+
+```bash
+# Check and regenerate .mo, .l10n.php and .json files if missing or outdated
+vendor/bin/publishpress-translate --sync-files
+```
+
+**What this does:**
+- **Automatically regenerates** `.mo` files if missing or older than `.po`
+- **Automatically regenerates** `.json` files if existing and outdated
+- **Automatically regenerates** `.l10n.php` files if existing and outdated
+- **Detects** orphaned files (without corresponding `.po` source)
+
+**When to use:**
+- Before deploying your plugin to ensure WordPress has the latest translations
+- After manually editing or updated `.po` files
+- To clean up orphaned translation files
+
+**File Format Support:**
+- **`.mo`** (compiled binary) - Automatically regenerated if missing or outdated
+- **`.json`** (JSON translation format) - Automatically regenerated if existing and outdated
+- **`.l10n.php`** (PHP translation format) - Automatically regenerated if existing and outdated
 
 ### Default Languages
 
@@ -334,6 +392,13 @@ The following languages should not be translated by Potomatic, they are handled 
 - Brazilian Portuguese (pt_BR)
  
 These languages will be skipped during translation and upload processes, even if PO files exist for them.
+
+**How Skipped Languages Work:**
+
+1. **Translation (`composer translate`)** - Skipped languages are not passed to Potomatic AI translation
+2. **Upload (`composer translate:upload`)** - Skipped languages are NOT uploaded to Weblate
+3. **Download (`composer translate:download`)** - Skipped languages ARE downloaded from Weblate (translations can be pulled but not replaced by AI)
+4. **Cleaning/Syncing** - Skipped languages ARE operated on by `--clean-po` and `--sync-files` commands (useful for maintenance without risk of overwriting with AI)
 
 ### Preventing Plugin Name Translation
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ vendor/bin/publishpress-translate --repair-plurals
 
 **Note:** New translations are automatically repaired during the translation process, so you only need this for existing files.
 
+**Note:** The library automatically detects your environment (dev-workspace vs plugin root) and uses the correct vendor path.
+
 #### 5. Clean Duplicate Entries
 
 Remove duplicate extracted comments from all `.po` files:

--- a/bin/publishpress-translate
+++ b/bin/publishpress-translate
@@ -98,6 +98,8 @@ $options = getopt('', [
     'download',
     'upload',
     'repair-plurals',
+    'clean-po',
+    'sync-files',
     'help',
 ]);
 
@@ -119,6 +121,8 @@ Options:
   --download             Download translations from Weblate (instead of generating)
   --upload               Upload existing translations to Weblate (no AI translation)
   --repair-plurals       Repair malformed plural entries in existing .po files
+  --clean-po             Clean duplicate entries from all .po files
+  --sync-files           Ensure .po, .mo, .json, .l10n.php files are synchronized
   --help                 Show this help message
 
 Examples:
@@ -128,7 +132,9 @@ Examples:
   publishpress-translate --force                   # Force re-translate all
   publishpress-translate --download                # Download from Weblate
   publishpress-translate --upload                  # Upload existing translations to Weblate
-  publishpress-translate --repair-plurals           # Fix malformed plural entries in .po files
+  publishpress-translate --repair-plurals          # Fix malformed plural entries in .po files
+  publishpress-translate --clean-po                # Remove duplicate entries from .po files
+  publishpress-translate --sync-files              # Synchronize all translation files
 
 Environment Variables:
   OPENAI_API_KEY        Required for AI translations (not needed for --dry-run or --download)
@@ -139,6 +145,11 @@ Workflow:
   2. Review in Weblate:      https://weblate.publishpress.com/
   3. Download updates:       publishpress-translate --download
   4. Build plugin with translations in /languages folder
+
+Maintenance:
+  - Clean duplicates:        publishpress-translate --clean-po
+  - Fix plural formats:      publishpress-translate --repair-plurals
+  - Sync .po/.mo files:      publishpress-translate --sync-files
 
 HELP;
     exit(0);
@@ -163,6 +174,10 @@ try {
     // Check mode
     if (isset($options['repair-plurals'])) {
         $result = $translator->repairPluralEntries();
+    } elseif (isset($options['clean-po'])) {
+        $result = $translator->cleanPoFiles();
+    } elseif (isset($options['sync-files'])) {
+        $result = $translator->syncPoAndMoFiles();
     } elseif (isset($options['download'])) {
         $result = $translator->downloadFromWeblate();
     } elseif (isset($options['upload'])) {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -266,6 +266,208 @@ class Translator
     }
 
     /**
+     * Clean duplicate entries from all PO files
+     *
+     * @return bool
+     */
+    public function cleanPoFiles()
+    {
+        echo "\n✨ Cleaning duplicate entries from .po files\n";
+        echo str_repeat('=', 50) . "\n\n";
+        echo "Path: {$this->languagesDir}\n\n";
+
+        $poFiles = glob($this->languagesDir . '/*.po');
+
+        if (empty($poFiles)) {
+            fwrite(STDERR, "No .po files found in {$this->languagesDir}\n");
+            return false;
+        }
+
+        echo "Found " . count($poFiles) . " .po file(s)\n\n";
+
+        if (!$this->weblateClient) {
+            fwrite(STDERR, "Warning: Weblate client not initialized.\n");
+            fwrite(STDERR, "Some cleanup operations may be limited.\n\n");
+        }
+
+        $cleaned = 0;
+        $cleanedWith = [];
+
+        foreach ($poFiles as $poFile) {
+            $baseName = basename($poFile);
+            $before = file_get_contents($poFile);
+
+            if ($this->weblateClient) {
+                $this->weblateClient->cleanupDuplicatePoHeaders($poFile);
+                $this->weblateClient->removeDuplicateReferences($poFile);
+                $this->weblateClient->removeDuplicateExtractedComments($poFile);
+            }
+
+            $after = file_get_contents($poFile);
+
+            if ($before !== $after) {
+                $cleaned++;
+                echo "  ✓ Cleaned: {$baseName}\n";
+
+                $moFile = substr($poFile, 0, -3) . '.mo';
+                $this->convertPoToMo($poFile, $moFile);
+            } else {
+                echo "  ⊘ Clean: {$baseName}\n";
+            }
+        }
+
+        echo "\n" . str_repeat('=', 50) . "\n";
+
+        if ($cleaned > 0) {
+            echo "✨ Cleaned {$cleaned} file(s) with duplicate entries.\n\n";
+        } else {
+            echo "✨ All .po files are already clean — no duplicates found.\n\n";
+        }
+
+        return true;
+    }
+
+    /**
+     * Sync .po and generated files (.mo, .json, .l10n.php) — ensure files are in sync with .po files
+     *
+     * @return bool
+     */
+    public function syncPoAndMoFiles()
+    {
+        echo "\n🔄 Synchronizing translation files (.po, .mo, .json, .l10n.php)\n";
+        echo str_repeat('=', 50) . "\n\n";
+        echo "Path: {$this->languagesDir}\n\n";
+
+        $poFiles = glob($this->languagesDir . '/*.po') ?: [];
+        $moFiles = glob($this->languagesDir . '/*.mo') ?: [];
+        $jsonFiles = glob($this->languagesDir . '/*.json') ?: [];
+        $phpFiles = glob($this->languagesDir . '/*.l10n.php') ?: [];
+
+        $totalFiles = count($poFiles) + count($moFiles) + count($jsonFiles) + count($phpFiles);
+        if ($totalFiles === 0) {
+            fwrite(STDERR, "No translation files found in {$this->languagesDir}\n");
+            return false;
+        }
+
+        echo "Found:\n";
+        echo "  " . count($poFiles) . " .po file(s)\n";
+        echo "  " . count($moFiles) . " .mo file(s)\n";
+        echo "  " . count($jsonFiles) . " .json file(s)\n";
+        echo "  " . count($phpFiles) . " .l10n.php file(s)\n\n";
+
+        $regenerated = 0;
+        $orphaned = [];
+        $needsGeneration = [];
+
+        // Check all .po files and ensure corresponding generated files are up-to-date
+        foreach ($poFiles as $poFile) {
+            $baseName = basename($poFile, '.po');
+            $poMtime = filemtime($poFile);
+
+            // Check .mo file
+            $moFile = $this->languagesDir . '/' . $baseName . '.mo';
+            if (!file_exists($moFile)) {
+                echo "  🔨 Regenerate: {$baseName}.mo (missing)\n";
+                $this->convertPoToMo($poFile, $moFile);
+                $regenerated++;
+            } else {
+                $moMtime = filemtime($moFile);
+                if ($poMtime > $moMtime) {
+                    echo "  🔨 Regenerate: {$baseName}.mo (outdated)\n";
+                    $this->convertPoToMo($poFile, $moFile);
+                    $regenerated++;
+                } else {
+                    echo "  ✓ Synced: {$baseName}.po ↔ .mo\n";
+                }
+            }
+
+            // Check .json file
+            $jsonFile = $this->languagesDir . '/' . $baseName . '.json';
+            if (file_exists($jsonFile)) {
+                $jsonMtime = filemtime($jsonFile);
+                if ($poMtime > $jsonMtime) {
+                    echo "  🔨 Regenerate: {$baseName}.json (outdated)\n";
+                    $this->convertPoToJson($poFile, $jsonFile, $baseName);
+                    $regenerated++;
+                } else {
+                    echo "  ✓ Synced: {$baseName}.po ↔ .json\n";
+                }
+            }
+
+            // Check .l10n.php file
+            $phpFile = $this->languagesDir . '/' . $baseName . '.l10n.php';
+            if (file_exists($phpFile)) {
+                $phpMtime = filemtime($phpFile);
+                if ($poMtime > $phpMtime) {
+                    echo "  🔨 Regenerate: {$baseName}.l10n.php (outdated)\n";
+                    $this->convertPoToL10nPhp($poFile, $phpFile, $baseName);
+                    $regenerated++;
+                } else {
+                    echo "  ✓ Synced: {$baseName}.po ↔ .l10n.php\n";
+                }
+            }
+        }
+
+        // Find orphaned .mo files
+        if (!empty($moFiles)) {
+            foreach ($moFiles as $moFile) {
+                $poFile = substr($moFile, 0, -3) . '.po';
+                if (!file_exists($poFile)) {
+                    $orphaned[] = basename($moFile);
+                }
+            }
+        }
+
+        // Find orphaned .json files
+        if (!empty($jsonFiles)) {
+            foreach ($jsonFiles as $jsonFile) {
+                $poFile = substr($jsonFile, 0, -5) . '.po';
+                if (!file_exists($poFile)) {
+                    $orphaned[] = basename($jsonFile);
+                }
+            }
+        }
+
+        // Find orphaned .l10n.php files
+        if (!empty($phpFiles)) {
+            foreach ($phpFiles as $phpFile) {
+                $poFile = str_replace('.l10n.php', '.po', $phpFile);
+                if (!file_exists($poFile)) {
+                    $orphaned[] = basename($phpFile);
+                }
+            }
+        }
+
+        echo "\n" . str_repeat('=', 50) . "\n";
+
+        if ($regenerated > 0) {
+            echo "✨ Regenerated {$regenerated} file(s) to match .po files.\n";
+        } else {
+            echo "✨ All translation files are up-to-date.\n";
+        }
+
+        if (!empty($needsGeneration)) {
+            echo "\n⚠️  Found " . count($needsGeneration) . " file(s) that need regeneration:\n";
+            foreach ($needsGeneration as $file) {
+                echo "  - {$file}\n";
+            }
+            echo "\nRun 'composer translate:compile' to regenerate these files from their .po sources.\n";
+        }
+
+        if (!empty($orphaned)) {
+            echo "\n⚠️  Found " . count($orphaned) . " orphaned file(s) without corresponding .po:\n";
+            foreach ($orphaned as $file) {
+                echo "  - {$file}\n";
+            }
+            echo "\nConsider removing these files or recreating their .po sources.\n";
+        }
+
+        echo "\n";
+
+        return true;
+    }
+
+    /**
      * Reverse-map Weblate language codes to WordPress locale codes
      *
      * @param string $weblateCode
@@ -1306,6 +1508,7 @@ class Translator
 
                         $this->weblateClient->cleanupDuplicatePoHeaders($poFile);
                         $this->weblateClient->removeDuplicateReferences($poFile);
+                        $this->weblateClient->removeDuplicateExtractedComments($poFile);
                         
                         $this->revertPluginNameTranslations($poFile);
                         
@@ -1529,6 +1732,163 @@ class Translator
     }
 
     /**
+     * Convert PO file to .l10n.php file
+     *
+     * @param string $poFile Path to PO file
+     * @param string $phpFile Path to output .l10n.php file
+     * @param string $baseName Base filename
+     * @return bool True on success
+     */
+    private function convertPoToL10nPhp($poFile, $phpFile, $baseName)
+    {
+        $entries = [];
+        $currentEntry = null;
+        $lines = file($poFile, FILE_IGNORE_NEW_LINES);
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            if (empty($line) || $line[0] === '#') {
+                continue;
+            }
+
+            if (strpos($line, 'msgid') === 0) {
+                if ($currentEntry && !empty($currentEntry['msgid']) && !empty($currentEntry['msgstr'])) {
+                    $entries[] = $currentEntry;
+                }
+                $currentEntry = ['msgid' => $this->extractString($line), 'msgstr' => ''];
+            } elseif (strpos($line, 'msgstr') === 0 && $currentEntry) {
+                $currentEntry['msgstr'] = $this->extractString($line);
+            } elseif ($line[0] === '"' && $currentEntry !== null) {
+                $continuationText = $this->extractString($line);
+                if ($currentEntry['msgstr'] !== '') {
+                    $currentEntry['msgstr'] .= $continuationText;
+                } else if ($currentEntry['msgid'] !== '') {
+                    $currentEntry['msgid'] .= $continuationText;
+                }
+            }
+        }
+
+        if ($currentEntry && !empty($currentEntry['msgid']) && !empty($currentEntry['msgstr'])) {
+            $entries[] = $currentEntry;
+        }
+
+        // Extract domain from filename
+        $domain = preg_replace('/-[a-z_]+$/i', '', $baseName);
+
+        // Build the l10n.php array structure
+        $localeData = ['messages' => []];
+        
+        // Add empty header entry
+        $localeData['messages'][''] = [
+            0 => '',
+            1 => '',
+        ];
+
+        // Add all translation entries
+        foreach ($entries as $entry) {
+            $localeData['messages'][$entry['msgid']] = [
+                0 => $entry['msgid'],
+                1 => $entry['msgstr'],
+            ];
+        }
+
+        // Build the final PHP array
+        $exported = var_export([
+            'domain' => $domain,
+            'locale_data' => $localeData,
+        ], true);
+        $minified = preg_replace('/\s+/', ' ', $exported);
+        $phpContent = "<?php\nreturn " . $minified . ";\n";
+
+        $written = file_put_contents($phpFile, $phpContent) !== false;
+        if ($written) {
+            chmod($phpFile, 0644);
+        }
+
+        return $written;
+    }
+
+    /**
+     * Convert PO file to .json file
+     *
+     * @param string $poFile Path to PO file
+     * @param string $jsonFile Path to output .json file
+     * @param string $baseName Base filename
+     * @return bool True on success
+     */
+    private function convertPoToJson($poFile, $jsonFile, $baseName)
+    {
+        $entries = [];
+        $currentEntry = null;
+        $lines = file($poFile, FILE_IGNORE_NEW_LINES);
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            if (empty($line) || $line[0] === '#') {
+                continue;
+            }
+
+            if (strpos($line, 'msgid') === 0) {
+                if ($currentEntry && !empty($currentEntry['msgid']) && !empty($currentEntry['msgstr'])) {
+                    $entries[] = $currentEntry;
+                }
+                $currentEntry = ['msgid' => $this->extractString($line), 'msgstr' => ''];
+            } elseif (strpos($line, 'msgstr') === 0 && $currentEntry) {
+                $currentEntry['msgstr'] = $this->extractString($line);
+            } elseif ($line[0] === '"' && $currentEntry !== null) {
+                $continuationText = $this->extractString($line);
+                if ($currentEntry['msgstr'] !== '') {
+                    $currentEntry['msgstr'] .= $continuationText;
+                } else if ($currentEntry['msgid'] !== '') {
+                    $currentEntry['msgid'] .= $continuationText;
+                }
+            }
+        }
+
+        if ($currentEntry && !empty($currentEntry['msgid']) && !empty($currentEntry['msgstr'])) {
+            $entries[] = $currentEntry;
+        }
+
+        // Extract domain from filename
+        $domain = preg_replace('/-[a-z_]+$/i', '', $baseName);
+
+        // Build the JSON structure
+        $jsonData = [
+            'translation-revision-date' => date('Y-m-d H:i:s+0000'),
+            'generator' => 'PublishPress Translation Tool',
+            'source' => 'wp-content/plugins/' . $this->getPluginSlug(),
+            'domain' => $domain,
+            'locale_data' => [
+                'messages' => [
+                    '' => [
+                        'domain' => $domain,
+                        'lang' => str_replace('_', '-', substr($baseName, strpos($baseName, '-') + 1)),
+                    ],
+                ],
+            ],
+        ];
+
+        // Add all translation entries
+        foreach ($entries as $entry) {
+            $jsonData['locale_data']['messages'][$entry['msgid']] = [
+                $entry['msgid'],
+                $entry['msgstr'],
+            ];
+        }
+
+        // Write JSON file
+        $jsonContent = json_encode($jsonData, JSON_UNESCAPED_UNICODE) . "\n";
+        $written = file_put_contents($jsonFile, $jsonContent) !== false;
+        if ($written) {
+            chmod($jsonFile, 0644);
+        }
+
+        return $written;
+    }
+
+    /**
      * Mark identical translations as fuzzy in PO file
      *
      * @param string $poFile
@@ -1607,6 +1967,11 @@ class Translator
         echo "Plugin: {$pluginSlug}\n";
         echo "Path: {$this->pluginRoot}\n";
         echo "Languages: " . implode(', ', $this->targetLanguages) . "\n";
+        
+        if (!empty($this->skippedLanguages)) {
+            echo "Skipped: " . implode(', ', $this->skippedLanguages) . " (handled by human translators)\n";
+        }
+        
         echo "Mode: " . ($this->dryRun ? 'DRY RUN (no API calls)' : 'LIVE TRANSLATION') . "\n";
         echo "Weblate: " . ($this->weblateEnabled ? 'Enabled' : 'Disabled') . "\n\n";
 
@@ -1672,6 +2037,7 @@ class Translator
                         if ($this->weblateClient) {
                             $this->weblateClient->cleanupDuplicatePoHeaders($poFile);
                             $this->weblateClient->removeDuplicateReferences($poFile);
+                            $this->weblateClient->removeDuplicateExtractedComments($poFile);
                         }
 
                         $this->repairPluralPipeDelimitedEntries($poFile);

--- a/src/WeblateClient.php
+++ b/src/WeblateClient.php
@@ -659,6 +659,58 @@ class WeblateClient
     }
 
     /**
+     * Remove duplicate extracted comment (#.) lines from PO file
+     * Each msgid in a .po file should only have one extracted comment per unique comment text.
+     *
+     * @param string $poFilePath
+     * @return void
+     */
+    public function removeDuplicateExtractedComments($poFilePath)
+    {
+        $content = @file_get_contents($poFilePath);
+        if ($content === false || $content === '') {
+            return;
+        }
+        
+        $lines = explode("\n", $content);
+        $result = [];
+        $seenInEntry = [];
+        $modified = false;
+        
+        for ($i = 0; $i < count($lines); $i++) {
+            $line = $lines[$i];
+            $trimmed = trim($line);
+            
+            // Check if this is an extracted comment line
+            if (preg_match('/^#\.\s*(.*)$/', $trimmed, $matches)) {
+                $commentText = $matches[1];
+                
+                // If we've already seen this exact comment in the current entry, 
+                // skip adding this duplicate to the result
+                if (isset($seenInEntry[$commentText])) {
+                    $modified = true;
+                    continue;
+                }
+                
+                // First occurrence of this comment - mark it and add it
+                $seenInEntry[$commentText] = true;
+                $result[] = $line;
+            } else {
+                if (empty($trimmed)) {
+                    $seenInEntry = [];
+                }
+                
+                $result[] = $line;
+            }
+        }
+        
+        $cleanedContent = implode("\n", $result);
+        if ($modified) {
+            file_put_contents($poFilePath, $cleanedContent);
+        }
+    }
+
+    /**
      * Remove fuzzy flag from PO file header
      *
      * @param string $poFilePath


### PR DESCRIPTION
- Add --clean-po command: Remove duplicate headers, references, and extracted comments from all .po files
- Add --sync-files command: Auto-regenerate .mo, .json, and .l10n.php files
- Update README with --clean-po and --sync-files command documentation

fix #77 