### PR TITLE
Apply WEBLATE_API_TIMEOUT to both connection and request timeouts

### DIFF
--- a/src/WeblateClient.php
+++ b/src/WeblateClient.php
@@ -65,6 +65,7 @@ class WeblateClient
                 'Accept' => 'application/json',
             ],
             'timeout' => (int) $timeout,
+            'connect_timeout' => (int) $timeout,
         ]);
     }
 


### PR DESCRIPTION
- Add connect_timeout configuration to Guzzle client
- Previously only 'timeout' (request timeout) was set, causing connection attempts to use Guzzle's default 300-second connect_timeout
- Now WEBLATE_API_TIMEOUT controls both connection establishment and response wait times