### PR TITLE
Add TranslationCountCheck and integrate into audit process

### DIFF
--- a/src/Audit/Auditor.php
+++ b/src/Audit/Auditor.php
@@ -14,6 +14,7 @@ use PublishPress\Translations\Audit\Checks\PoVersionCheck;
 use PublishPress\Translations\Audit\Checks\PotMismatchCheck;
 use PublishPress\Translations\Audit\Checks\SourceI18nCheck;
 use PublishPress\Translations\Audit\Checks\TextChangeCheck;
+use PublishPress\Translations\Audit\Checks\TranslationCountCheck;
 use PublishPress\Translations\Output;
 
 final class Auditor
@@ -86,6 +87,7 @@ final class Auditor
             new PotMismatchCheck(),
             new PoVersionCheck(),
             new SourceI18nCheck(),
+            new TranslationCountCheck(),
         ];
 
         $allFindings = [];

--- a/src/Audit/CheckId.php
+++ b/src/Audit/CheckId.php
@@ -22,6 +22,8 @@ final class CheckId
 
     public const SOURCE_I18N = 'source-i18n';
 
+    public const TRANSLATION_COUNT = 'translation-count';
+
     /**
      * @return string[]
      */
@@ -34,6 +36,7 @@ final class CheckId
             self::POT_MISMATCH,
             self::PO_VERSION,
             self::SOURCE_I18N,
+            self::TRANSLATION_COUNT,
         ];
     }
 
@@ -54,6 +57,7 @@ final class CheckId
             self::POT_MISMATCH        => 'POT vs PO mismatch',
             self::PO_VERSION          => 'PO header',
             self::SOURCE_I18N         => 'Source strings vs POT',
+            self::TRANSLATION_COUNT   => 'Translation string counts',
         ];
 
         return $map[$id] ?? $id;

--- a/src/Audit/Checks/SourceI18nCheck.php
+++ b/src/Audit/Checks/SourceI18nCheck.php
@@ -209,7 +209,7 @@ final class SourceI18nCheck implements AuditCheckInterface
 
             $findings[] = new AuditFinding(
                 $this->id(),
-                'info',
+                $missingCount > 0 ? 'warning' : 'info',
                 $potName,
                 '',
                 sprintf(

--- a/src/Audit/Checks/TranslationCountCheck.php
+++ b/src/Audit/Checks/TranslationCountCheck.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Counts translatable strings in the .pot and each locale .po file.
+ *
+ * @package PublishPress\Translations\Audit\Checks
+ */
+
+namespace PublishPress\Translations\Audit\Checks;
+
+use PublishPress\Translations\Audit\AuditCheckInterface;
+use PublishPress\Translations\Audit\AuditContext;
+use PublishPress\Translations\Audit\AuditFinding;
+use PublishPress\Translations\Audit\CheckId;
+use PublishPress\Translations\Audit\IssueSlug;
+use PublishPress\Translations\Audit\Support\PoFile;
+
+final class TranslationCountCheck implements AuditCheckInterface
+{
+    public function id(): string
+    {
+        return CheckId::TRANSLATION_COUNT;
+    }
+
+    public function title(): string
+    {
+        return 'Translation string counts';
+    }
+
+    public function run(AuditContext $ctx): array
+    {
+        $findings = [];
+        $strict   = $ctx->options()->strictPo();
+        $dir      = $ctx->languagesDir();
+
+        $potFiles = glob($dir . '/*.pot') ?: [];
+        if ($potFiles === []) {
+            $findings[] = new AuditFinding(
+                $this->id(),
+                'info',
+                '',
+                '',
+                'No .pot files — skipping string count.',
+                null,
+                null,
+                null,
+                null,
+                null,
+                IssueSlug::NO_POT_IN_LANGUAGES
+            );
+
+            return $findings;
+        }
+
+        foreach ($potFiles as $potPath) {
+            $potBase = basename($potPath, '.pot');
+            $relPot  = ltrim(str_replace($ctx->pluginRoot(), '', $potPath), '/\\');
+
+            try {
+                $potPo = PoFile::fromFile($potPath, $strict);
+            } catch (\Throwable $e) {
+                $findings[] = new AuditFinding(
+                    $this->id(),
+                    'warning',
+                    $relPot,
+                    '',
+                    'Parse error: ' . $e->getMessage(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    IssueSlug::POT_PARSE_ERROR
+                );
+                continue;
+            }
+
+            $potKeys  = $potPo->msgidKeySet();
+            $potCount = count($potKeys);
+
+            $findings[] = new AuditFinding(
+                $this->id(),
+                'info',
+                $relPot,
+                '',
+                'POT has ' . $potCount . ' translatable string(s)',
+                null,
+                null,
+                null,
+                null,
+                null,
+                IssueSlug::POT_STRING_COUNT
+            );
+
+            foreach ($ctx->targetLanguages() as $locale) {
+                $poPath = $dir . '/' . $potBase . '-' . $locale . '.po';
+                if (!is_file($poPath)) {
+                    continue;
+                }
+
+                $relPo = ltrim(str_replace($ctx->pluginRoot(), '', $poPath), '/\\');
+
+                try {
+                    $localePo = PoFile::fromFile($poPath, $strict);
+                } catch (\Throwable $e) {
+                    $findings[] = new AuditFinding(
+                        $this->id(),
+                        'warning',
+                        $relPo,
+                        $locale,
+                        'Parse error: ' . $e->getMessage(),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        IssueSlug::PO_PARSE_ERROR
+                    );
+                    continue;
+                }
+
+                $poKeys  = $localePo->msgidKeySet();
+                $poCount = count($poKeys);
+                $extra   = count(array_diff_key($poKeys, $potKeys));
+                $missing = count(array_diff_key($potKeys, $poKeys));
+
+                $summary = sprintf(
+                    '%d string(s) — %d extra, %d missing (POT: %d)',
+                    $poCount,
+                    $extra,
+                    $missing,
+                    $potCount
+                );
+
+                $severity = $missing > 0 ? 'warning' : 'info';
+                $findings[] = new AuditFinding(
+                    $this->id(),
+                    $severity,
+                    $relPo,
+                    $locale,
+                    $summary,
+                    null,
+                    null,
+                    null,
+                    null,
+                    $summary,
+                    IssueSlug::TRANSLATION_COUNT_SUMMARY
+                );
+            }
+        }
+
+        return $findings;
+    }
+}

--- a/src/Audit/IssueSlug.php
+++ b/src/Audit/IssueSlug.php
@@ -67,6 +67,10 @@ final class IssueSlug
 
     public const JS_PARSE_ERROR = 'js-parse-error';
 
+    public const POT_STRING_COUNT = 'pot-string-count';
+
+    public const TRANSLATION_COUNT_SUMMARY = 'translation-count-summary';
+
     public static function fallbackForCheckId(string $checkId): string
     {
         switch ($checkId) {
@@ -82,6 +86,8 @@ final class IssueSlug
                 return 'po-header';
             case CheckId::SOURCE_I18N:
                 return self::SOURCE_STRING_MISSING_FROM_POT;
+            case CheckId::TRANSLATION_COUNT:
+                return self::TRANSLATION_COUNT_SUMMARY;
             default:
                 return 'audit-issue';
         }

--- a/src/Audit/Report/HtmlAuditReportRenderer.php
+++ b/src/Audit/Report/HtmlAuditReportRenderer.php
@@ -10,6 +10,7 @@ namespace PublishPress\Translations\Audit\Report;
 
 use PublishPress\Translations\Audit\AuditFinding;
 use PublishPress\Translations\Audit\CheckId;
+use PublishPress\Translations\Audit\IssueSlug;
 
 final class HtmlAuditReportRenderer implements AuditReportRendererInterface
 {
@@ -51,7 +52,9 @@ final class HtmlAuditReportRenderer implements AuditReportRendererInterface
             $tabBar .= '<button type="button" class="tab-btn" role="tab" aria-selected="false" data-panel="' . self::h($panelId) . '">' . $label . '</button>';
 
             $list = $byCheck[$cid] ?? [];
-            if ($list === []) {
+            if ($cid === CheckId::TRANSLATION_COUNT) {
+                $body = self::buildTranslationCountBody($list);
+            } elseif ($list === []) {
                 $body = '<p class="all-clear">Everything passed — no issues reported for this check.</p>';
             } else {
                 $rows = '';
@@ -254,6 +257,84 @@ final class HtmlAuditReportRenderer implements AuditReportRendererInterface
             . '<td><code>' . self::h($f->resolvedIssueSlug()) . '</code></td>'
             . '<td>' . $msgCell . '</td>'
             . "</tr>\n";
+    }
+
+    /**
+     * @param AuditFinding[] $list
+     */
+    private static function buildTranslationCountBody(array $list): string
+    {
+        if ($list === []) {
+            return '<p class="all-clear">No string count data available.</p>';
+        }
+
+        $potHtml = '';
+        $rows    = '';
+
+        foreach ($list as $f) {
+            if ($f->issueSlug === IssueSlug::NO_POT_IN_LANGUAGES) {
+                return '<p>' . self::h($f->message) . '</p>';
+            }
+
+            if ($f->issueSlug === IssueSlug::POT_PARSE_ERROR) {
+                $potHtml .= '<p><span class="badge fail">POT parse error:</span> ' . self::h($f->message) . '</p>';
+                continue;
+            }
+
+            if ($f->issueSlug === IssueSlug::POT_STRING_COUNT && $f->language === '') {
+                $potHtml .= '<p><strong>' . self::h($f->message) . '</strong></p>';
+                continue;
+            }
+
+            if ($f->issueSlug === IssueSlug::PO_PARSE_ERROR) {
+                $rows .= '<tr>'
+                    . '<td>' . self::h($f->language) . '</td>'
+                    . '<td colspan="3"><span class="badge fail">Parse error:</span> ' . self::h($f->message) . '</td>'
+                    . "</tr>\n";
+                continue;
+            }
+
+            if ($f->issueSlug === IssueSlug::TRANSLATION_COUNT_SUMMARY) {
+                $poCount = 0;
+                $extra   = 0;
+                $missing = 0;
+                if (preg_match('/^(\d+) string\(s\) — (\d+) extra, (\d+) missing/', $f->message, $m)) {
+                    $poCount = (int) $m[1];
+                    $extra   = (int) $m[2];
+                    $missing = (int) $m[3];
+                }
+
+                if ($extra > 0 && $missing > 0) {
+                    $extraBadge   = '<span class="badge fail">' . $extra . '</span>';
+                    $missingBadge = '<span class="badge fail">' . $missing . '</span>';
+                } elseif ($extra > 0) {
+                    $extraBadge   = '<span class="badge warn">' . $extra . '</span>';
+                    $missingBadge = (string) $missing;
+                } elseif ($missing > 0) {
+                    $extraBadge   = (string) $extra;
+                    $missingBadge = '<span class="badge warn">' . $missing . '</span>';
+                } else {
+                    $extraBadge   = '<span class="badge ok">' . $extra . '</span>';
+                    $missingBadge = '<span class="badge ok">' . $missing . '</span>';
+                }
+
+                $rows .= '<tr>'
+                    . '<td>' . self::h($f->language) . '</td>'
+                    . '<td>' . $poCount . '</td>'
+                    . '<td>' . $extraBadge . '</td>'
+                    . '<td>' . $missingBadge . '</td>'
+                    . "</tr>\n";
+            }
+        }
+
+        $table = '';
+        if ($rows !== '') {
+            $table = '<table class="findings-table"><thead><tr>'
+                . '<th>Language</th><th>Strings in PO</th><th>Extra (PO ∖ POT)</th><th>Missing (POT ∖ PO)</th>'
+                . '</tr></thead><tbody>' . $rows . '</tbody></table>';
+        }
+
+        return $potHtml . $table;
     }
 
     private static function h(string $s): string


### PR DESCRIPTION
- Introduced TranslationCountCheck to count translatable strings in .pot and .po files.
- Updated CheckId and IssueSlug to include new constants for translation count checks.
- Enhanced HtmlAuditReportRenderer to display translation count findings.
- Adjusted SourceI18nCheck to improve warning severity based on missing strings.