### PR TITLE
Add upload-pot option to publishpress-translate for uploading only PO…

### DIFF
--- a/bin/publishpress-translate
+++ b/bin/publishpress-translate
@@ -146,6 +146,7 @@ $options = getopt('', [
     'languages:',
     'download',
     'upload',
+    'upload-pot',
     'repair-plurals',
     'clean-po',
     'sync-files',
@@ -176,6 +177,7 @@ Options:
   --languages=LANGS      Comma-separated language codes (default: all configured)
   --download             Download translations from Weblate (instead of generating)
   --upload               Upload existing translations to Weblate (no AI translation)
+  --upload-pot           Upload only the POT file (source strings) to Weblate, without uploading PO files
   --repair-plurals       Repair malformed plural entries in existing .po files
   --clean-po             Clean duplicate entries from all .po files
   --sync-files           Check status of .po and compiled formats (.mo, .json, .l10n.php)
@@ -198,6 +200,7 @@ Examples:
   publishpress-translate --force                   # Force re-translate all
   publishpress-translate --download                # Download from Weblate
   publishpress-translate --upload                  # Upload existing translations to Weblate
+  publishpress-translate --upload-pot              # Upload only the POT source strings to Weblate
   publishpress-translate --repair-plurals          # Fix malformed plural entries in .po files
   publishpress-translate --clean-po                # Remove duplicate entries from .po files
   publishpress-translate --sync-files              # Check if translated files are up-to-date
@@ -295,6 +298,7 @@ try {
         'sync-files'     => 'syncPoAndMoFiles',
         'download'       => 'downloadFromWeblate',
         'upload'         => 'uploadToWeblate',
+        'upload-pot'     => 'uploadPotToWeblate',
         'audit'          => 'audit',
     ];
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -2400,6 +2400,68 @@ class Translator
     }
 
     /**
+     * Upload only the POT file (source strings) to Weblate
+     *
+     * @return bool
+     */
+    public function uploadPotToWeblate()
+    {
+        if (!$this->weblateClient) {
+            fwrite(STDERR, "Error: Weblate not configured.\n");
+            fwrite(STDERR, "Please set WEBLATE_API_TOKEN environment variable.\n\n");
+            return false;
+        }
+
+        $pluginSlug = $this->getPluginSlug();
+        $start = $this->writeCliBannerAndPluginContext();
+
+        $potFiles = $this->findPotFiles();
+
+        if (empty($potFiles)) {
+            fwrite(STDERR, "Error: No .pot files found in {$this->languagesDir}\n");
+            $this->writeCliCompletion($start, false);
+            return false;
+        }
+
+        $this->output->phase('Uploading POT file(s) to Weblate');
+        $this->output->step('POT files found: ' . count($potFiles));
+
+        $projectSlug = $this->getWeblateProjectSlug();
+        $success = true;
+
+        foreach ($potFiles as $potFile) {
+            $potFileName   = basename($potFile);
+            $textDomain    = str_replace('.pot', '', $potFileName);
+            $componentSlug = $this->getWeblateComponentSlug($textDomain);
+
+            $this->output->separator();
+            $this->output->step('POT file: ' . $potFileName);
+            $this->output->step('Component: ' . $componentSlug);
+
+            if (!$this->weblateClient->componentExists($projectSlug, $componentSlug)) {
+                fwrite(STDERR, "  ⚠️  Component '{$componentSlug}' not found on Weblate, skipping.\n");
+                $success = false;
+                continue;
+            }
+
+            try {
+                $this->weblateClient->uploadPot($projectSlug, $componentSlug, $potFile);
+                $this->output->step('POT uploaded successfully');
+                $this->output->step('View at: https://weblate.publishpress.com/projects/' . $projectSlug . '/' . $componentSlug . '/');
+            } catch (Exception $e) {
+                fwrite(STDERR, "  ❌ Failed to upload POT for {$textDomain}: " . $e->getMessage() . "\n");
+                $success = false;
+            }
+        }
+
+        $this->output->separator();
+        $this->output->line('POT upload ' . ($success ? 'complete' : 'finished with errors') . " for {$pluginSlug}.");
+        $this->writeCliCompletion($start, $success);
+
+        return $success;
+    }
+
+    /**
      * Get Weblate project slug from composer.json or config
      *
      * @return string


### PR DESCRIPTION
…T files

- Introduced a new command-line option `--upload-pot` to the publishpress-translate script.
- Implemented the `uploadPotToWeblate` method in the Translator class to handle the upload of POT files to Weblate.
- Updated documentation to reflect the new functionality and usage examples.