### PR TITLE
docs(agent): Cursor agent guide and project rules

### DIFF
--- a/.cursor/rules/audit-checks.mdc
+++ b/.cursor/rules/audit-checks.mdc
@@ -1,0 +1,38 @@
+---
+description: How to add or change translation audit checks
+globs: src/Audit/**
+alwaysApply: false
+---
+
+# Audit checks
+
+## Checklist (new check)
+
+1. `Checks/MyCheck.php` — `final`, implements `AuditCheckInterface`.
+2. `CheckId::MY_*` + `all()` + `label()`.
+3. `IssueSlug` constants for each finding type.
+4. Register in `Auditor` `$checks` array (order = run order).
+5. `bin/publishpress-translate` `--help` + README if user-facing.
+
+## `run(AuditContext $ctx)` pattern
+
+- Read paths from `$ctx->languagesDir()`, `$ctx->pluginRoot()`, `$ctx->targetLanguages()`.
+- Parse PO via `PoFile::fromFile($path, $ctx->options()->strictPo())` — catch parse errors → `AuditFinding` warning + `IssueSlug::PO_PARSE_ERROR`.
+- Respect overrides: `TranslationOverrides::mapForLanguage($locale)` where empty counts apply.
+- Return `AuditFinding[]` only; no writes unless check is `TextChangeCheck` (revert path).
+
+## Severity
+
+- `info` — advisory (e.g. no POT).
+- `warning` — should fix; may still exit 0.
+- `error` — fails audit run.
+
+## Text check only
+
+- AI: `AiWorthinessJudge`; cost via `AuditOptions::maxCostUsd()`.
+- Interactive / allow-edit / report: `AuditOptions` modes; only this check mutates PO.
+
+## Reports
+
+- CLI: short `message` + optional preview in message.
+- Files: `reportSummary` headline + `reportDetailLines` full list (no truncation in details).

--- a/.cursor/rules/caveman.mdc
+++ b/.cursor/rules/caveman.mdc
@@ -1,0 +1,11 @@
+---
+description: Caveman agent replies; normal commits and PRs
+alwaysApply: true
+---
+
+# Communication
+
+- **User-facing agent text**: caveman full (`/caveman full`) — terse, no fluff; keep technical terms exact.
+- **Exceptions (normal English)**: security warnings, irreversible ops, multi-step instructions user must follow.
+- **Git commits, PR titles/bodies, CHANGELOG**: normal English; Conventional Commits (`type(scope): summary`).
+- **Code, PHPDoc, README**: normal English; match existing tone.

--- a/.cursor/rules/php-translator.mdc
+++ b/.cursor/rules/php-translator.mdc
@@ -1,0 +1,35 @@
+---
+description: PHP and CLI conventions for src/ and bin/
+globs: "{src/**/*.php,bin/**,scripts/**/*.php}"
+alwaysApply: false
+---
+
+# PHP / CLI
+
+## Namespace
+
+`PublishPress\Translations\` — audit under `...\Audit\`, shared under `...\Support\`.
+
+## Entry flow
+
+`bin/publishpress-translate` → load autoload + `.env` → `Translator` method from flag map (`audit`, `download`, `translate`, …).
+
+## Translator changes
+
+- **Default**: extract new workflow to dedicated class; call from `Translator`.
+- **Exception**: tiny one-liner delegation or bugfix in existing private method.
+- Weblate: `WeblateClient.php`. Overrides: `TranslationOverrides.php` only.
+
+## Output
+
+- User messages via `Output` (`banner`, `phase`, `success`, `warning`).
+- `Output` has phpcs ignore for CLI non-HTML escape — do not copy that pattern into HTML report renderers.
+
+## gettext
+
+- Library uses **gettext v4** (`gettext/gettext` ^4.8). `--audit-strict-po` may be no-op where v5 unavailable.
+
+## Docblocks
+
+- File-level `@package PublishPress\Translations` (or `...\Audit\...`).
+- `@param` / `@return` on non-trivial public APIs.

--- a/.cursor/rules/potomatic.mdc
+++ b/.cursor/rules/potomatic.mdc
@@ -1,0 +1,28 @@
+---
+description: Potomatic is external — do not edit potomatic/
+globs: potomatic/**
+alwaysApply: false
+---
+
+# Potomatic — external dependency (read-only)
+
+`potomatic/` is a **bundled copy of upstream Potomatic** (GravityKit). **Do not edit** files under `potomatic/` in this repo.
+
+- No fixes, prompts, providers, tests, or config changes in `potomatic/`.
+- Need different AI/batch behavior → change **upstream Potomatic** or bump the vendored copy via maintainer workflow — **not** agent edits here.
+
+## What agents may change (PHP only)
+
+- `src/Translator.php` — `buildCommand()`, flags passed to CLI, dictionary temp dir, paths via `getPotomaticPath()`
+- `scripts/setup-potomatic.php` — install `node_modules` only (if packaging changes)
+- `composer.json` `setup-potomatic` script — install hook only
+
+## Integration reference (read-only)
+
+PHP invokes `potomatic.js` with e.g. `--target-languages`, `--pot-file-path`, `--output-dir`, `--po-file-prefix`, `--model`, `--batch-size`, `--jobs`, `--max-cost`, `--api-key`, optional `--use-dictionary` + `--dictionary-path`.
+
+PublishPress-specific terms: `config/dictionaries.json` + env overrides → temp dictionary JSON for Potomatic (built in PHP, not in `potomatic/config/`).
+
+## If task sounds like “fix Potomatic”
+
+Stop. Implement in PHP (wrappers, post-process PO, audit checks, Weblate flow) or escalate dependency update. **Never patch `potomatic/src`.**

--- a/.cursor/rules/practices.mdc
+++ b/.cursor/rules/practices.mdc
@@ -1,0 +1,58 @@
+---
+description: Established and target engineering practices for this library
+alwaysApply: true
+---
+
+# Practices — keep and extend
+
+## Architecture (established)
+
+- **Audit = strategy**: one `AuditCheckInterface` class per concern; register only in `Auditor`.
+- **IDs**: `CheckId` (CLI `--audit-only`) and `IssueSlug` (reports/filters) — constants, not magic strings.
+- **Options**: `AuditOptions` immutable via `with*()`; validate on build (`InvalidArgumentException`).
+- **Context**: pass `AuditContext` into `run()`; no globals for plugin root, languages dir, or API key.
+- **Findings**: build `AuditFinding` with `issueSlug`; use `reportSummary` / `reportDetailLines` for file reports; CLI text can differ.
+- **DRY across Translator + audit**: shared helpers in `src/Support/` and `src/Audit/Support/` (e.g. `TranslationOverrides`, `PoFile`).
+- **Renderers**: new report format → `AuditReportRendererInterface` + `AuditReportRendererFactory` + `AuditReportFormat`.
+- **CLI output**: use `Output` (banner, phases, bullets) — not ad-hoc `echo` in audit checks.
+
+## God files (aspirational — important)
+
+- **`src/Translator.php` is legacy god file** (~3000 lines). **Do not grow it** for new behavior.
+- **New features**: new focused class under `src/` (e.g. Weblate runner, PO tools), thin delegation from `Translator`.
+- **Refactors welcome** when touching an area: extract method cluster → class, leave `Translator` as facade.
+
+## Potomatic (hard rule)
+
+- **`potomatic/` is external** — bundled upstream, **read-only** in this repo.
+- **Never** edit JS under `potomatic/` (src, config, tests, package.json).
+- Translation/AI behavior changes → **PHP** (`Translator`, dictionaries, audit) or **upstream Potomatic release**, not local patches.
+
+## PHP constraints
+
+- Minimum **PHP 7.2.5** per `composer.json`.
+- Avoid without fallback: typed properties, arrows, `??=`, unions, `match`, named args, `str_contains` / `str_starts_with` / `str_ends_with`.
+- Prefer **`final`** on concrete audit/support classes; interfaces for extension (`AuditCheckInterface`, `AuditReportRendererInterface`).
+- **PSR-12** + PublishPress PHPCS; run `composer check:cs` and `check:php` (compat matrix).
+
+## Safety
+
+- **Never commit** `.env`, API keys, tokens.
+- **OpenAI / Weblate**: dry-run or exit early when keys missing (live translate).
+- **Cost limits**: respect `--audit-max-cost` and Potomatic `--max-cost`.
+- **Subprocess**: `escapeshellarg` for all user-derived shell args.
+- **Audit in CI**: non-TTY / `CI` → report-only (no interactive prompts).
+
+## When adding public behavior
+
+- Update **CheckId + help + README** together for audit flags.
+- PHP unit tests for audit when added (none yet).
+
+## Anti-patterns
+
+- Duplicating override or PO parsing logic outside shared support classes.
+- New 200+ line methods in `Translator.php`.
+- Raw `echo` in audit checks (use `Output` via context).
+- Growing `Auditor::run()` with check logic — belongs in check class.
+- **Any edit under `potomatic/`** (including “small” prompt or retry fixes).
+- Fixing translation bugs in JS instead of PHP integration or dependency upgrade.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# AGENTS — library-publishpress-translator
+
+AI guide for Cursor agents. **User-facing replies: caveman full** (`/caveman full`). **Commits, PRs, CHANGELOG: normal English**, Conventional Commits.
+
+README = end-user docs. **This file wins on conflicts** for agent behavior.
+
+## What this repo is
+
+Composer package `publishpress/translations`. CLI `bin/publishpress-translate` → PHP orchestration + **Potomatic** (external Node dep, bundled) + optional **Weblate**.
+
+- **PHP (edit here)**: `src/` (`PublishPress\Translations\`), PSR-4 autoload
+- **Potomatic (do not edit)**: `potomatic/` — upstream bundle; PHP only shells out via `Translator::buildCommand()`
+- **Config (edit here)**: `config/dictionaries.json` (merged into temp dict for Potomatic)
+- **Dev**: Docker `./dev-workspace/run` (same checks as CI)
+
+## Layout / touch map
+
+| Change | Where |
+|--------|--------|
+| CLI flags, bootstrap | `bin/publishpress-translate` |
+| Translate / Weblate / Potomatic shell | `src/Translator.php` (legacy god file — see practices) |
+| Weblate HTTP | `src/WeblateClient.php` |
+| Overrides env parsing | `src/Support/TranslationOverrides.php` |
+| Audit orchestration | `src/Audit/Auditor.php` |
+| One audit rule | `src/Audit/Checks/*.php` |
+| Check IDs / labels | `src/Audit/CheckId.php` |
+| Finding slugs | `src/Audit/IssueSlug.php` |
+| Audit options (immutable) | `src/Audit/AuditOptions.php` |
+| PO/git/AI helpers | `src/Audit/Support/*` |
+| Report output | `src/Audit/Report/*` |
+| CLI UX | `src/Output.php` |
+| Potomatic CLI args / paths | `src/Translator.php` (`buildCommand`, `getPotomaticPath`) — **not** `potomatic/` |
+| Brand dictionary | `config/dictionaries.json` |
+
+## Practices we follow (keep doing)
+
+Detailed rules: `.cursor/rules/practices.mdc` (always on). Summary:
+
+**Architecture**
+
+- **Strategy checks**: one class per audit concern, `AuditCheckInterface`, register in `Auditor`.
+- **Stable IDs**: `CheckId` for `--audit-only`; `IssueSlug` for machine-readable findings.
+- **Immutable options**: `AuditOptions::defaults()` + `with*()`; validate in `with*`, not at read time.
+- **Shared domain logic**: e.g. `TranslationOverrides`, `PoFile` — Translator and audit must not diverge.
+- **Factories**: `AuditReportRendererFactory` (PHP audit reports).
+- **Context object**: pass `AuditContext` into checks; no global state.
+- **Findings model**: `AuditFinding` with `reportSummary` + `reportDetailLines` for files; CLI `message` can be verbose.
+- **Thin CLI**: `bin/` parses options → `Translator` / `Auditor`; heavy logic not in bin.
+
+**Safety / ops**
+
+- **Cost caps**: `--audit-max-cost`, Potomatic `--max-cost`; dry-run when no key.
+- **CI / non-TTY**: interactive audit → forced `report` (no prompts).
+- **Shell**: `escapeshellarg` on Potomatic args; never log API keys.
+- **Env**: `.env` only fills unset vars; shell wins.
+
+**Code style (PHP)**
+
+- **PHP ≥ 7.2.5** (match `composer.json`). No 7.3+ syntax without guarded fallback.
+- **PSR-12** + `PublishPressStandards` + `VariableAnalysis` (`.phpcs.xml`).
+- **`final`** on audit/support value types; interfaces for extension points.
+- **Early throw** `InvalidArgumentException` on bad CLI-derived config.
+- **PHPDoc** `@package` on files; typed params where 7.2 allows.
+
+**Potomatic**
+
+- **Never edit `potomatic/`** — external dependency; integrate from PHP only.
+- Dictionaries/overrides: PHP `config/dictionaries.json` + `TranslationOverrides` → temp files passed to CLI.
+
+## Practices we aspire to (do not regress)
+
+- **No god files**: `Translator.php` (~3k lines) is **known debt**. Do **not** add large features inline. Extract to `src/` classes (Weblate, subprocess runner, PO maintenance) and call from `Translator`.
+- **Never patch Potomatic** — behavior gaps → PHP layer or upstream version bump.
+- **One responsibility per new class**; mirror audit layout for new PHP subsystems.
+- **Sync public surface**: new `CheckId` → `CheckId::all()`, `label()`, `Auditor` list, `bin/` `--help`, README audit table.
+- **Run checks before done**: see Verify below. Prefer adding `check:stan` to CI when touching types.
+- **No PHP copy-paste across checks** — lift to `Audit\Support`.
+- **PHP tests** for audit checks (none yet) — add when behavior is non-trivial.
+- **README accuracy**: e.g. `--audit` locale set = `targetLanguages` ∪ `skippedLanguages` in code (not “skipped excluded” unless code changes).
+
+## Audit: add a check
+
+1. `src/Audit/Checks/MyCheck.php` implements `AuditCheckInterface`.
+2. `id()` → new `CheckId` const + `all()` + `label()`.
+3. New `IssueSlug` consts if needed (not generic fallback).
+4. Register in `Auditor.php` `$checks`.
+5. Update `bin/publishpress-translate` `--help` if user-facing.
+6. `./dev-workspace/run composer check:cs` (+ `check:stan` locally).
+
+## Verify
+
+```bash
+./dev-workspace/run composer install
+./dev-workspace/run composer check:lint
+./dev-workspace/run composer check:cs
+./dev-workspace/run composer check:php
+./dev-workspace/run composer check:stan   # local; not in root CI yet
+```
+
+Do **not** run Potomatic lint/tests as part of normal agent work — `potomatic/` is not maintained in this repo.
+
+## Drift watchlist
+
+| Topic | Agent truth |
+|-------|----------------|
+| Audit locales | `audit()` passes merged target + skipped langs |
+| Check `translation-count` | In `CheckId`; may be missing from README / CLI help |
+| PHPStan | `composer check:stan` exists; root `.github/workflows/code-check.yml` omits it |
+| Parent `publishpress/CLAUDE.md` | Plugin language-folder research — **not** this library |
+
+## Communication
+
+- Replies to user: **caveman full**.
+- Code comments: plain English, only non-obvious logic.
+- User docs edits: `README.md` / `CHANGELOG.md` — full sentences.


### PR DESCRIPTION
## Summary

Adds agent-oriented documentation so Cursor (and similar tools) can work on this library with less token waste and fewer wrong edits.

- **`AGENTS.md`** — repo map, touch targets, practices we follow vs aspire to, verify commands, known doc/code drift
- **`.cursor/rules/`** — focused rules:
  - `caveman.mdc` — caveman replies; normal commits/PRs
  - `practices.mdc` — architecture, god-file policy, PHP 7.2.5, safety
  - `php-translator.mdc` — `src/` and `bin/` conventions
  - `audit-checks.mdc` — how to add audit checks
  - `potomatic.mdc` — **Potomatic is external; do not edit `potomatic/`** (PHP integration only)

## Motivation

- No prior `AGENTS.md` or Cursor rules; agents repeatedly re-read the long README
- `Translator.php` is documented as known god-file debt — extract, do not grow
- Potomatic is a bundled upstream dependency — changes belong in PHP wrappers or upstream bumps, not local JS patches

## Test plan

- [ ] Open repo in Cursor; confirm rules load (`alwaysApply` + globs)
- [ ] Skim `AGENTS.md` for accuracy vs current layout
- [ ] No runtime/code changes — CI unchanged


Made with [Cursor](https://cursor.com)